### PR TITLE
Теперь массив новостей из интернета парсится и отображается в приложении

### DIFF
--- a/likeVKontakte.xcodeproj/project.pbxproj
+++ b/likeVKontakte.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		3AC5FF7B287300B000FB668F /* VKAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC5FF7A287300AE00FB668F /* VKAuthViewController.swift */; };
 		3AD41A91287348E100BAC61E /* MyFriends.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD41A90287348E100BAC61E /* MyFriends.swift */; };
 		3AD41A972877016D00BAC61E /* FriendJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD41A962877016D00BAC61E /* FriendJSON.swift */; };
+		3AE4172128A02DD5009E1AFE /* ParseNewsfeedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE4172028A02DD5009E1AFE /* ParseNewsfeedService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -89,6 +90,7 @@
 		3AC5FF7A287300AE00FB668F /* VKAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VKAuthViewController.swift; sourceTree = "<group>"; };
 		3AD41A90287348E100BAC61E /* MyFriends.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFriends.swift; sourceTree = "<group>"; };
 		3AD41A962877016D00BAC61E /* FriendJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendJSON.swift; sourceTree = "<group>"; };
+		3AE4172028A02DD5009E1AFE /* ParseNewsfeedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseNewsfeedService.swift; sourceTree = "<group>"; };
 		C8AE9E0B43A61B7F6AF8E041 /* Pods_likeVKontakte.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_likeVKontakte.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -244,6 +246,7 @@
 			isa = PBXGroup;
 			children = (
 				3A2CB8212860AC5B0017EF54 /* NetworkService.swift */,
+				3AE4172028A02DD5009E1AFE /* ParseNewsfeedService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -416,6 +419,7 @@
 				3AC5FF79286DEC5200FB668F /* StarView.swift in Sources */,
 				3AB27ED628780C6400EE7F1E /* NetworkData.swift in Sources */,
 				3A7CC4772880AC8F00ED5C6C /* NewsPostJSON.swift in Sources */,
+				3AE4172128A02DD5009E1AFE /* ParseNewsfeedService.swift in Sources */,
 				3A7D7EA328536AE8000A67E6 /* SceneDelegate.swift in Sources */,
 				3AC5FF7B287300B000FB668F /* VKAuthViewController.swift in Sources */,
 				3A7CC46B288020A000ED5C6C /* NewsViewController.swift in Sources */,

--- a/likeVKontakte/Controllers/Third tab (news)/NewsViewController.swift
+++ b/likeVKontakte/Controllers/Third tab (news)/NewsViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 
 class NewsViewController: UIViewController {
     
-    let testNews = NewsPost.testPosts
+    //let testNews = NewsPost.testPosts
+    var testNews = MyNewsPosts.shared.getMyNewsPosts()
     
     @IBOutlet weak var newsTableView: UITableView!
     
@@ -18,11 +19,28 @@ class NewsViewController: UIViewController {
     let reuseIdPostPhotoCell = "PostPhotoCell"
     let reuseIdPostLikesCell = "PostLikesCell"
     
+    let refreshControl = UIRefreshControl()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         newsTableView.delegate = self
         newsTableView.dataSource = self
+        //Pull to refresh control
+        refreshControl.attributedTitle = NSAttributedString(string: "Загрузка данных")
+        refreshControl.addTarget(self, action: #selector(self.refresh(_:)), for: .valueChanged)
+        newsTableView.addSubview(refreshControl)
     }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        newsTableView.reloadData()
+        testNews = MyNewsPosts.shared.getMyNewsPosts()
+        print(testNews.count)
+    }
+    //Pull to refresh (обновить данные в таблице)
+    @objc func refresh(_ sender: AnyObject) {
+        self.newsTableView.reloadData()
+        self.refreshControl.endRefreshing()
+}
 }
 
 extension NewsViewController: UITableViewDelegate, UITableViewDataSource {

--- a/likeVKontakte/Controllers/VKAuthViewController.swift
+++ b/likeVKontakte/Controllers/VKAuthViewController.swift
@@ -117,7 +117,7 @@ extension VKAuthViewController: WKNavigationDelegate {
              //MARK: - вызовы сервисов (get friends, groups) (шаг 3)
              let VKService = VKService(token: token, user_id: user_id)
              VKService.getGroupsAF {
-                 self.doNewsfeedRequest(token: token, user_id: user_id)
+                 parseNewsfeed(token: token, user_id: user_id)
                  self.doFriendsRequest(token: token,user_id: user_id)
              }
              
@@ -200,17 +200,18 @@ extension VKAuthViewController {
     }
 }
 // Проверка работы загрузки групп
-extension VKAuthViewController {
-    func doNewsfeedRequest(token: String, user_id: String) {
-        let service = VKService(token: token, user_id: user_id)
-        service.getNewsPosts { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(_):
-                print("Успешно загруженные новости")
-            case .failure:
-                print("Случилась ошибка в отгрузке новостей")
-            }
-        }
-    }
-}
+//extension VKAuthViewController {
+//    func doNewsfeedRequest(token: String, user_id: String) {
+//        let service = VKService(token: token, user_id: user_id)
+//        service.getNewsPosts { [weak self] result in
+//            guard let self = self else { return }
+//            switch result {
+//            case .success((let items, let groups, let profiles)):
+//                print("TEEESTTTT", items[0].text)
+//                print("Успешно загруженные новости")
+//            case .failure:
+//                print("Случилась ошибка в отгрузке новостей")
+//            }
+//        }
+//    }
+//}

--- a/likeVKontakte/Models/NewsPostJSON.swift
+++ b/likeVKontakte/Models/NewsPostJSON.swift
@@ -16,13 +16,44 @@ struct NewsPostRoot: Decodable {
 // MARK: - Response
 struct NewsPostResponse: Decodable {
     let items: [NewsPostItem]
+    let profiles: [NewsPostProfile]
+    let groups: [NewsPostGroup]
 }
 
 struct NewsPostItem: Decodable {
     let source_id: Int
     let text: String
     let attachments: [ItemAttachmentNewsPost]?
-    
+    let likes: Likes
+}
+struct Likes: Decodable {
+    let count: Int
+}
+
+struct NewsPostGroup: Decodable {
+    let id: Int
+    let name: String
+    let photo100: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case photo100 = "photo_100"
+    }
+}
+
+struct NewsPostProfile: Decodable {
+    let id: Int
+    let screenName: String
+    let photo100: String
+    let firstName, lastName: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case screenName = "screen_name"
+        case photo100 = "photo_100"
+        case firstName = "first_name"
+        case lastName = "last_name"
+    }
 }
 
 struct ItemAttachmentNewsPost: Decodable {

--- a/likeVKontakte/Services/ParseNewsfeedService.swift
+++ b/likeVKontakte/Services/ParseNewsfeedService.swift
@@ -1,0 +1,64 @@
+//
+//  ParseNewsfeedService.swift
+//  likeVKontakte
+//
+//  Created by Антон Голубейков on 07.08.2022.
+//
+
+import Foundation
+
+//MARK: - Создает экземпляр новости
+private func createNewsPost(items: [NewsPostItem], groups: [NewsPostGroup], profiles: [NewsPostProfile]) {
+    var titlePhoto: String = ""
+    var titleName: String = ""
+    
+    var bodyText: String = ""
+    var bodyPhoto: String = ""
+    
+    var numberOfLikes: Int = 0
+    
+    for item in items {
+        bodyText = item.text
+        if item.source_id > 0 {
+            for profile in profiles {
+                if profile.id == item.source_id {
+                    titleName = profile.firstName + profile.lastName
+                    titlePhoto = profile.photo100
+                }
+            }
+        } else {
+            for group in groups {
+                if group.id == abs(item.source_id) {
+                    titleName = group.name
+                    titlePhoto = group.photo100
+                }
+            }
+        }
+        if let attachment = item.attachments?[0].photo?.sizes[1].url {
+            bodyPhoto = attachment
+        }
+        numberOfLikes = item.likes.count
+        
+        let newsPost = NewsPost(titlePhoto: titlePhoto, titleName: titleName, bodyText: bodyText, bodyPhoto: bodyPhoto, numberOfLikes: numberOfLikes)
+        MyNewsPosts.shared.addNewsPost(newsPost: newsPost)
+        titlePhoto = ""
+        titleName = ""
+        bodyText = ""
+        bodyPhoto = ""
+        numberOfLikes = 0
+    }
+}
+// MARK: - Парсит декодированный из интернета JSON
+func parseNewsfeed(token: String, user_id: String) {
+    let service = VKService(token: token, user_id: user_id)
+    service.getNewsPosts { result in
+        switch result {
+        case .success((let items, let groups, let profiles)):
+            createNewsPost(items: items, groups: groups, profiles: profiles)
+            print("Успешно загруженные новости")
+        case .failure:
+            print("Случилась ошибка в отгрузке новостей")
+        }
+    }
+}
+

--- a/likeVKontakte/Storage/MyNewsPosts.swift
+++ b/likeVKontakte/Storage/MyNewsPosts.swift
@@ -24,7 +24,7 @@ class MyNewsPosts {
     }
     
     func addNewsPost(newsPost: NewsPost) {
-        if !myNewsPosts.contains(where: { $0 == newsPost }) {
+        if !myNewsPosts.contains(where: { $0.bodyText == newsPost.bodyText }) {
         myNewsPosts.append(newsPost)
         }
     }

--- a/likeVKontakte/Views/Base.lproj/Main.storyboard
+++ b/likeVKontakte/Views/Base.lproj/Main.storyboard
@@ -297,14 +297,14 @@
                                             <outlet property="bodyText" destination="OuP-bJ-mNv" id="PBb-Wr-3uH"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="PostPhotoCell" rowHeight="206" translatesAutoresizingMaskIntoConstraints="NO" id="CFH-g0-aSh" customClass="PostPhotoCell" customModule="likeVKontakte" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="PostPhotoCell" rowHeight="206" translatesAutoresizingMaskIntoConstraints="NO" id="CFH-g0-aSh" customClass="PostPhotoCell" customModule="likeVKontakte" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="218" width="390" height="206"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CFH-g0-aSh" id="7Mb-jS-XQd">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="206"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hWe-eK-UO4">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hWe-eK-UO4">
                                                     <rect key="frame" x="15" y="10" width="360" height="186"/>
                                                 </imageView>
                                             </subviews>

--- a/likeVKontakte/Views/Third tab (news)/PostAuthorCell.swift
+++ b/likeVKontakte/Views/Third tab (news)/PostAuthorCell.swift
@@ -13,7 +13,24 @@ class PostAuthorCell: UITableViewCell {
     @IBOutlet weak var titleName: UILabel!
     
     func configureCell(post: NewsPost) {
-        titlePhoto.image = UIImage(named: post.titlePhoto)
+        if let photoLocal = UIImage(named: post.titlePhoto) {
+            titlePhoto.image = photoLocal
+        } else if let photoInternetLoaded = UIImage(data: {
+            do {
+                guard let url = URL(string: post.titlePhoto) else { return Data() }
+                let data = try Data(contentsOf: url)
+                return data
+        } catch {
+            print("нет такого url")
+            print(post.titlePhoto)
+            return Data()
+        }
+        }()
+        )
+        {
+            titlePhoto.image = photoInternetLoaded
+        }
+        
         titleName.text = post.titleName
         titlePhoto.layer.cornerRadius = titlePhoto.frame.width/2
         titlePhoto.clipsToBounds = true

--- a/likeVKontakte/Views/Third tab (news)/PostPhotoCell.swift
+++ b/likeVKontakte/Views/Third tab (news)/PostPhotoCell.swift
@@ -13,6 +13,23 @@ class PostPhotoCell: UITableViewCell {
     
     func configureCell(post: NewsPost) {
         bodyPhoto.image = UIImage(named: post.bodyPhoto)
+        
+        if let photoLocal = UIImage(named: post.bodyPhoto) {
+            bodyPhoto.image = photoLocal
+        } else if let photoInternetLoaded = UIImage(data: {
+            do {
+                guard let url = URL(string: post.bodyPhoto) else { return Data() }
+                let data = try Data(contentsOf: url)
+                return data
+        } catch {
+            print("нет такого url")
+            print(post.bodyPhoto)
+            return Data()
+        }
+        }()
+        )
+        {
+            bodyPhoto.image = photoInternetLoaded
+        }
     }
-
 }


### PR DESCRIPTION
Теперь массив новостей из интернета парсится и отображается в таблице. Сначала через DispatchGroup полученный из интернета массив раскладывается на 3 группы (items, profiles, groups). Далее отдельный сервис собирает из полученных массивов экземпляры новостей, которые уже отображаются в приложении. Прикрепил скрин с боевыми данными из интернета. 
<img width="284" alt="Снимок экрана 2022-08-07 в 23 53 37" src="https://user-images.githubusercontent.com/47087482/183310739-9159600e-a3d0-44bd-810e-6a941fafc4cc.png">

